### PR TITLE
Handle version 3 ternary exports

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,28 @@
+# Troubleshooting
+
+## Windows: sentencepiece build fails during gguf install
+
+When `pip` tries to install `gguf` on Windows it may need to build `sentencepiece` from
+source. With the latest `cmake` (3.31+) this fails with an error similar to:
+
+```
+Compatibility with CMake < 3.5 has been removed from CMake.
+```
+
+This happens because the bundled `sentencepiece` project still advertises
+compatibility with very old CMake policy versions. You can resolve the issue in
+either of two ways:
+
+1. **Pin CMake to an older release** – before installing the requirements run:
+   ```powershell
+   pip install "cmake<3.31"
+   ```
+   and retry the installation.
+
+2. **Install a prebuilt wheel** – install a binary `sentencepiece` wheel that
+   matches your Python version (for example `pip install sentencepiece==0.1.99`)
+   and then proceed with `pip install -r requirements.txt`. Because the wheel is
+   already present `pip` will skip building from source.
+
+Either approach avoids the failing CMake configure step and lets the
+installation continue normally.

--- a/run_inference.py
+++ b/run_inference.py
@@ -1,19 +1,30 @@
-import os
-import sys
-import signal
-import platform
 import argparse
+import os
+import platform
+import signal
 import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from utils.ternary_loader import (
+    TernaryModel,
+    is_ternary_file,
+    load_ternary_model,
+    materialize_layer,
+)
+
 
 def run_command(command, shell=False):
     """Run a system command and ensure it succeeds."""
     try:
         subprocess.run(command, shell=shell, check=True)
-    except subprocess.CalledProcessError as e:
-        print(f"Error occurred while running command: {e}")
+    except subprocess.CalledProcessError as exc:
+        print(f"Error occurred while running command: {exc}")
         sys.exit(1)
 
-def run_inference():
+
+def _resolve_llama_cli() -> str:
     build_dir = "build"
     if platform.system() == "Windows":
         main_path = os.path.join(build_dir, "bin", "Release", "llama-cli.exe")
@@ -21,36 +32,194 @@ def run_inference():
             main_path = os.path.join(build_dir, "bin", "llama-cli")
     else:
         main_path = os.path.join(build_dir, "bin", "llama-cli")
+    return main_path
+
+
+def run_llama_cli(args):
+    main_path = _resolve_llama_cli()
     command = [
-        f'{main_path}',
-        '-m', args.model,
-        '-n', str(args.n_predict),
-        '-t', str(args.threads),
-        '-p', args.prompt,
-        '-ngl', '0',
-        '-c', str(args.ctx_size),
-        '--temp', str(args.temperature),
-        "-b", "1",
+        f"{main_path}",
+        "-m",
+        args.model,
+        "-n",
+        str(args.n_predict),
+        "-t",
+        str(args.threads),
+        "-p",
+        args.prompt,
+        "-ngl",
+        "0",
+        "-c",
+        str(args.ctx_size),
+        "--temp",
+        str(args.temperature),
+        "-b",
+        "1",
     ]
     if args.conversation:
         command.append("-cnv")
     run_command(command)
 
-def signal_handler(sig, frame):
+
+def _load_transformers():
+    try:
+        import torch  # noqa: F401
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        print(
+            "Error: ternary inference requires the 'torch' and 'transformers' packages. "
+            "Install them with `pip install torch transformers`."
+        )
+        raise SystemExit(1) from exc
+
+    return AutoModelForCausalLM, AutoTokenizer
+
+
+def _prepare_hf_components(model_metadata: dict, hf_override: Optional[str]):
+    AutoModelForCausalLM, AutoTokenizer = _load_transformers()
+    model_name = hf_override or model_metadata.get("model_name")
+    if not model_name:
+        print(
+            "Error: metadata for the ternary export is missing the base model name. "
+            "Pass --hf-base to specify the Hugging Face identifier manually."
+        )
+        sys.exit(1)
+
+    print(f"Loading Hugging Face model '{model_name}' for ternary inference...")
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    return model, tokenizer
+
+
+def _apply_ternary_weights(model, ternary_model: TernaryModel):
+    import torch
+
+    named_modules = dict(model.named_modules())
+    for layer_name, layer in ternary_model.layers.items():
+        module = named_modules.get(layer_name)
+        if module is None or not hasattr(module, "weight"):
+            print(f"Warning: layer '{layer_name}' not found in base model; skipping.")
+            continue
+
+        weights = materialize_layer(layer)
+        weight_tensor = torch.from_numpy(weights).to(module.weight.dtype)
+        module.weight.data.copy_(weight_tensor)
+
+        if layer.bias is not None and getattr(module, "bias", None) is not None:
+            bias_tensor = torch.from_numpy(layer.bias).to(module.bias.dtype)
+            module.bias.data.copy_(bias_tensor)
+
+
+def run_ternary_inference(args):
+    ternary_path = Path(args.model)
+    print(f"Detected ternary export at '{ternary_path}'. Using Python inference path.")
+    ternary_model = load_ternary_model(ternary_path)
+    model, tokenizer = _prepare_hf_components(
+        ternary_model.metadata, hf_override=args.hf_base
+    )
+
+    _apply_ternary_weights(model, ternary_model)
+
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - defensive guard
+        print("Error: torch is required for ternary inference.")
+        sys.exit(1)
+
+    torch.set_num_threads(args.threads)
+    model.eval()
+
+    encoded = tokenizer(args.prompt, return_tensors="pt")
+    max_new_tokens = max(args.n_predict, 1)
+    generation_kwargs = {
+        "max_new_tokens": max_new_tokens,
+        "temperature": args.temperature,
+        "do_sample": args.temperature > 0,
+        "pad_token_id": tokenizer.eos_token_id,
+    }
+
+    with torch.no_grad():
+        output_ids = model.generate(**encoded, **generation_kwargs)
+
+    print(tokenizer.decode(output_ids[0], skip_special_tokens=True))
+
+
+def run_inference(args):
+    if args.model.lower().endswith(".ternary") or is_ternary_file(args.model):
+        run_ternary_inference(args)
+    else:
+        run_llama_cli(args)
+
+
+def signal_handler(sig, frame):  # pragma: no cover - CLI guard
     print("Ctrl+C pressed, exiting...")
     sys.exit(0)
 
+
 if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
-    # Usage: python run_inference.py -p "Microsoft Corporation is an American multinational corporation and technology company headquartered in Redmond, Washington."
-    parser = argparse.ArgumentParser(description='Run inference')
-    parser.add_argument("-m", "--model", type=str, help="Path to model file", required=False, default="models/bitnet_b1_58-3B/ggml-model-i2_s.gguf")
-    parser.add_argument("-n", "--n-predict", type=int, help="Number of tokens to predict when generating text", required=False, default=128)
-    parser.add_argument("-p", "--prompt", type=str, help="Prompt to generate text from", required=True)
-    parser.add_argument("-t", "--threads", type=int, help="Number of threads to use", required=False, default=2)
-    parser.add_argument("-c", "--ctx-size", type=int, help="Size of the prompt context", required=False, default=2048)
-    parser.add_argument("-temp", "--temperature", type=float, help="Temperature, a hyperparameter that controls the randomness of the generated text", required=False, default=0.8)
-    parser.add_argument("-cnv", "--conversation", action='store_true', help="Whether to enable chat mode or not (for instruct models.)")
+    parser = argparse.ArgumentParser(description="Run inference")
+    parser.add_argument(
+        "-m",
+        "--model",
+        type=str,
+        help="Path to model file",
+        required=False,
+        default="models/bitnet_b1_58-3B/ggml-model-i2_s.gguf",
+    )
+    parser.add_argument(
+        "-n",
+        "--n-predict",
+        type=int,
+        help="Number of tokens to predict when generating text",
+        required=False,
+        default=128,
+    )
+    parser.add_argument(
+        "-p",
+        "--prompt",
+        type=str,
+        help="Prompt to generate text from",
+        required=True,
+    )
+    parser.add_argument(
+        "-t",
+        "--threads",
+        type=int,
+        help="Number of threads to use",
+        required=False,
+        default=2,
+    )
+    parser.add_argument(
+        "-c",
+        "--ctx-size",
+        type=int,
+        help="Size of the prompt context",
+        required=False,
+        default=2048,
+    )
+    parser.add_argument(
+        "-temp",
+        "--temperature",
+        type=float,
+        help="Temperature, a hyperparameter that controls the randomness of the generated text",
+        required=False,
+        default=0.8,
+    )
+    parser.add_argument(
+        "--hf-base",
+        type=str,
+        help=(
+            "Override the Hugging Face model identifier to use when hydrating ternary exports. "
+            "This is useful if the export metadata is missing or you want to use a local path."
+        ),
+    )
+    parser.add_argument(
+        "-cnv",
+        "--conversation",
+        action="store_true",
+        help="Whether to enable chat mode or not (for instruct models.)",
+    )
 
-    args = parser.parse_args()
-    run_inference()
+    parsed_args = parser.parse_args()
+    run_inference(parsed_args)

--- a/run_inference_server.py
+++ b/run_inference_server.py
@@ -1,19 +1,23 @@
-import os
-import sys
-import signal
-import platform
 import argparse
+import os
+import platform
+import signal
 import subprocess
+import sys
+
+from utils.ternary_loader import is_ternary_file
+
 
 def run_command(command, shell=False):
     """Run a system command and ensure it succeeds."""
     try:
         subprocess.run(command, shell=shell, check=True)
-    except subprocess.CalledProcessError as e:
-        print(f"Error occurred while running command: {e}")
+    except subprocess.CalledProcessError as exc:
+        print(f"Error occurred while running command: {exc}")
         sys.exit(1)
 
-def run_server():
+
+def _resolve_llama_server() -> str:
     build_dir = "build"
     if platform.system() == "Windows":
         server_path = os.path.join(build_dir, "bin", "Release", "llama-server.exe")
@@ -21,44 +25,113 @@ def run_server():
             server_path = os.path.join(build_dir, "bin", "llama-server")
     else:
         server_path = os.path.join(build_dir, "bin", "llama-server")
-    
+    return server_path
+
+
+def run_server(args):
+    if args.model.lower().endswith(".ternary") or is_ternary_file(args.model):
+        print("Error: The HTTP server does not yet support ternary models.")
+        sys.exit(1)
+
+    server_path = _resolve_llama_server()
+
     command = [
-        f'{server_path}',
-        '-m', args.model,
-        '-c', str(args.ctx_size),
-        '-t', str(args.threads),
-        '-n', str(args.n_predict),
-        '-ngl', '0',
-        '--temp', str(args.temperature),
-        '--host', args.host,
-        '--port', str(args.port),
-        '-cb'  # Enable continuous batching
+        f"{server_path}",
+        "-m",
+        args.model,
+        "-c",
+        str(args.ctx_size),
+        "-t",
+        str(args.threads),
+        "-n",
+        str(args.n_predict),
+        "-ngl",
+        "0",
+        "--temp",
+        str(args.temperature),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "-cb",
     ]
-    
+
     if args.prompt:
-        command.extend(['-p', args.prompt])
-    
-    # Note: -cnv flag is removed as it's not supported by the server
-    
+        command.extend(["-p", args.prompt])
+
     print(f"Starting server on {args.host}:{args.port}")
     run_command(command)
 
-def signal_handler(sig, frame):
+
+def signal_handler(sig, frame):  # pragma: no cover - CLI guard
     print("Ctrl+C pressed, shutting down server...")
     sys.exit(0)
 
+
 if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
-    
-    parser = argparse.ArgumentParser(description='Run llama.cpp server')
-    parser.add_argument("-m", "--model", type=str, help="Path to model file", required=False, default="models/bitnet_b1_58-3B/ggml-model-i2_s.gguf")
-    parser.add_argument("-p", "--prompt", type=str, help="System prompt for the model", required=False)
-    parser.add_argument("-n", "--n-predict", type=int, help="Number of tokens to predict", required=False, default=4096)
-    parser.add_argument("-t", "--threads", type=int, help="Number of threads to use", required=False, default=2)
-    parser.add_argument("-c", "--ctx-size", type=int, help="Size of the context window", required=False, default=2048)
-    parser.add_argument("--temperature", type=float, help="Temperature for sampling", required=False, default=0.8)
-    parser.add_argument("--host", type=str, help="IP address to listen on", required=False, default="127.0.0.1")
-    parser.add_argument("--port", type=int, help="Port to listen on", required=False, default=8080)
-    
-    args = parser.parse_args()
-    run_server()
+
+    parser = argparse.ArgumentParser(description="Run llama.cpp server")
+    parser.add_argument(
+        "-m",
+        "--model",
+        type=str,
+        help="Path to model file",
+        required=False,
+        default="models/bitnet_b1_58-3B/ggml-model-i2_s.gguf",
+    )
+    parser.add_argument(
+        "-p",
+        "--prompt",
+        type=str,
+        help="System prompt for the model",
+        required=False,
+    )
+    parser.add_argument(
+        "-n",
+        "--n-predict",
+        type=int,
+        help="Number of tokens to predict",
+        required=False,
+        default=4096,
+    )
+    parser.add_argument(
+        "-t",
+        "--threads",
+        type=int,
+        help="Number of threads to use",
+        required=False,
+        default=2,
+    )
+    parser.add_argument(
+        "-c",
+        "--ctx-size",
+        type=int,
+        help="Size of the context window",
+        required=False,
+        default=2048,
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        help="Temperature for sampling",
+        required=False,
+        default=0.8,
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        help="IP address to listen on",
+        required=False,
+        default="127.0.0.1",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Port to listen on",
+        required=False,
+        default=8080,
+    )
+
+    parsed_args = parser.parse_args()
+    run_server(parsed_args)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(GGML_HEADERS_BITNET ../include/ggml-bitnet.h)
-set(GGML_SOURCES_BITNET ggml-bitnet-mad.cpp)
-set(GGML_SOURCES_BITNET ggml-bitnet-lut.cpp)
+set(GGML_SOURCES_BITNET
+    ggml-bitnet-mad.cpp
+    ggml-bitnet-lut.cpp
+    ggml-bitnet-multiplane.cpp)
 
 include_directories(3rdparty/llama.cpp/ggml/include)
 

--- a/src/ggml-bitnet-multiplane.cpp
+++ b/src/ggml-bitnet-multiplane.cpp
@@ -1,0 +1,179 @@
+#include "ggml-bitnet.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+static inline size_t row_byte_stride(int columns) {
+    const size_t bits_per_row = static_cast<size_t>(columns);
+    return (bits_per_row + 7) / 8;
+}
+
+static inline bool check_io(float * output, const float * input, const ternary_multiplane_tensor * weight) {
+    return output != nullptr && input != nullptr && weight != nullptr;
+}
+
+static inline bool check_masks(const ternary_multiplane_tensor * tensor) {
+    for (int plane = 0; plane < 3; ++plane) {
+        if (tensor->pos_masks[plane] == nullptr || tensor->neg_masks[plane] == nullptr) {
+            return false;
+        }
+    }
+    return tensor->group_scales != nullptr || tensor->n_groups == 0;
+}
+
+} // namespace
+
+extern "C" void bitnet_multiplane_gemv(
+    float * output,
+    const float * input,
+    const ternary_multiplane_tensor * weight,
+    int M,
+    int N) {
+    if (!check_io(output, input, weight) || !check_masks(weight)) {
+        return;
+    }
+
+    std::fill_n(output, static_cast<size_t>(M), 0.0f);
+
+    for (int plane = 0; plane < 3; ++plane) {
+        const float plane_scale = weight->plane_scales[plane];
+        bitnet_gemv_ternary_plane(
+            output,
+            input,
+            weight->pos_masks[plane],
+            weight->neg_masks[plane],
+            plane_scale,
+            M,
+            N);
+    }
+
+    if (weight->group_scales == nullptr || weight->n_groups <= 0) {
+        return;
+    }
+
+    const int32_t group_size = weight->group_size;
+    for (int32_t group = 0; group < weight->n_groups; ++group) {
+        const int32_t start = group * group_size;
+        const int32_t end = std::min(start + group_size, weight->n_rows);
+        const float scale = weight->group_scales[group];
+        for (int32_t row = start; row < end && row < M; ++row) {
+            output[row] *= scale;
+        }
+    }
+}
+
+extern "C" void bitnet_gemv_ternary_plane(
+    float * output,
+    const float * input,
+    const uint8_t * pos_mask,
+    const uint8_t * neg_mask,
+    float scale,
+    int M,
+    int N) {
+    if (output == nullptr || input == nullptr || pos_mask == nullptr || neg_mask == nullptr) {
+        return;
+    }
+
+    const size_t stride = row_byte_stride(N);
+    for (int row = 0; row < M; ++row) {
+        const uint8_t * pos_row = pos_mask + stride * static_cast<size_t>(row);
+        const uint8_t * neg_row = neg_mask + stride * static_cast<size_t>(row);
+
+        float acc = 0.0f;
+        int column = 0;
+        for (size_t byte = 0; byte < stride; ++byte) {
+            const uint8_t pos_byte = pos_row[byte];
+            const uint8_t neg_byte = neg_row[byte];
+
+            for (int bit = 0; bit < 8 && column < N; ++bit, ++column) {
+                const uint8_t mask = static_cast<uint8_t>(1u << bit);
+                if ((pos_byte & mask) != 0) {
+                    acc += input[column];
+                }
+                if ((neg_byte & mask) != 0) {
+                    acc -= input[column];
+                }
+            }
+        }
+
+        output[row] += acc * scale;
+    }
+}
+
+extern "C" ternary_multiplane_tensor * bitnet_load_multiplane_tensor(FILE * file) {
+    if (file == nullptr) {
+        return nullptr;
+    }
+
+    ternary_multiplane_tensor * tensor = new ternary_multiplane_tensor{};
+    tensor->group_scales = nullptr;
+    for (int plane = 0; plane < 3; ++plane) {
+        tensor->pos_masks[plane] = nullptr;
+        tensor->neg_masks[plane] = nullptr;
+        tensor->plane_scales[plane] = 0.0f;
+    }
+
+    auto cleanup = [&tensor]() {
+        bitnet_free_multiplane_tensor(tensor);
+        return static_cast<ternary_multiplane_tensor *>(nullptr);
+    };
+
+    if (std::fread(&tensor->n_rows, sizeof(int32_t), 1, file) != 1 ||
+        std::fread(&tensor->n_cols, sizeof(int32_t), 1, file) != 1 ||
+        std::fread(&tensor->group_size, sizeof(int32_t), 1, file) != 1 ||
+        std::fread(&tensor->n_groups, sizeof(int32_t), 1, file) != 1) {
+        return cleanup();
+    }
+
+    if (std::fread(tensor->plane_scales, sizeof(float), 3, file) != 3) {
+        return cleanup();
+    }
+
+    if (tensor->n_groups < 0) {
+        return cleanup();
+    }
+
+    if (tensor->n_groups > 0) {
+        tensor->group_scales = new float[tensor->n_groups];
+        if (std::fread(tensor->group_scales, sizeof(float), tensor->n_groups, file) != static_cast<size_t>(tensor->n_groups)) {
+            return cleanup();
+        }
+    }
+
+    const size_t packed_size = row_byte_stride(tensor->n_cols) * static_cast<size_t>(tensor->n_rows);
+
+    for (int plane = 0; plane < 3; ++plane) {
+        tensor->pos_masks[plane] = new uint8_t[packed_size];
+        tensor->neg_masks[plane] = new uint8_t[packed_size];
+
+        if (std::fread(tensor->pos_masks[plane], sizeof(uint8_t), packed_size, file) != packed_size ||
+            std::fread(tensor->neg_masks[plane], sizeof(uint8_t), packed_size, file) != packed_size) {
+            return cleanup();
+        }
+    }
+
+    return tensor;
+}
+
+extern "C" void bitnet_free_multiplane_tensor(ternary_multiplane_tensor * tensor) {
+    if (tensor == nullptr) {
+        return;
+    }
+
+    for (int plane = 0; plane < 3; ++plane) {
+        delete[] tensor->pos_masks[plane];
+        delete[] tensor->neg_masks[plane];
+        tensor->pos_masks[plane] = nullptr;
+        tensor->neg_masks[plane] = nullptr;
+    }
+
+    delete[] tensor->group_scales;
+    tensor->group_scales = nullptr;
+
+    delete tensor;
+}
+

--- a/utils/export_ternary_model.py
+++ b/utils/export_ternary_model.py
@@ -1,0 +1,322 @@
+"""Export 4-bit quantized models to the BitNet ternary multiplane format."""
+
+import argparse
+import json
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+try:
+    from transformers import AutoModelForCausalLM  # type: ignore
+
+    HAS_TRANSFORMERS = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAS_TRANSFORMERS = False
+    AutoModelForCausalLM = None  # type: ignore
+    print("Warning: transformers not installed")
+
+
+@dataclass
+class QuantizationConfig:
+    bits: int = 4
+    group_size: int = 128
+    symmetric: bool = True
+
+
+def quantize_tensor_to_4bit(
+    tensor: torch.Tensor, config: QuantizationConfig
+) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+    """Quantize a tensor into a 4-bit representation."""
+
+    original_shape = tensor.shape
+    tensor_flat = tensor.flatten()
+    num_elements = tensor_flat.numel()
+    num_groups = (num_elements + config.group_size - 1) // config.group_size
+
+    quantized = torch.zeros_like(tensor_flat, dtype=torch.int8)
+    scales: List[float] = []
+
+    for group_idx in range(num_groups):
+        start = group_idx * config.group_size
+        end = min((group_idx + 1) * config.group_size, num_elements)
+        group = tensor_flat[start:end]
+
+        abs_max = group.abs().max()
+        scale = abs_max / 7.0 if abs_max > 0 else 1.0
+
+        q_group = torch.round(group / scale).to(torch.int8)
+        q_group = torch.clamp(q_group, -8, 7)
+
+        quantized[start:end] = q_group
+        scales.append(float(scale))
+
+    metadata: Dict[str, torch.Tensor] = {
+        "scales": torch.tensor(scales, dtype=torch.float32),
+        "group_size": torch.tensor(config.group_size, dtype=torch.int32),
+        "shape": torch.tensor(original_shape, dtype=torch.int32),
+    }
+
+    return quantized.reshape(original_shape), metadata
+
+
+def int4_to_balanced_ternary(value: int) -> List[int]:
+    """Convert a 4-bit integer into its three-plane ternary coefficients."""
+
+    mapping = {
+        -8: [-1, 0, 1],
+        -7: [-1, 1, -1],
+        -6: [-1, 1, 0],
+        -5: [-1, 1, 1],
+        -4: [0, -1, -1],
+        -3: [0, -1, 0],
+        -2: [0, -1, 1],
+        -1: [0, 0, -1],
+        0: [0, 0, 0],
+        1: [0, 0, 1],
+        2: [0, 1, -1],
+        3: [0, 1, 0],
+        4: [0, 1, 1],
+        5: [1, -1, -1],
+        6: [1, -1, 0],
+        7: [1, -1, 1],
+    }
+    clamped = int(np.clip(value, -8, 7))
+    return mapping[clamped]
+
+
+class TernaryModelExporter:
+    """Convert and export a model in ternary multiplane format."""
+
+    def __init__(self, model_name: str = "gpt2") -> None:
+        self.model_name = model_name
+        self.config = QuantizationConfig()
+        self.layers_converted = 0
+        self.total_weights = 0
+        self.total_bytes = 0
+
+    def convert_linear_layer(self, layer: nn.Linear) -> Dict[str, np.ndarray]:
+        """Convert a single linear layer to the ternary multiplane format."""
+
+        if layer.in_features == 0 or layer.out_features == 0:
+            return {}
+
+        weight_4bit, metadata = quantize_tensor_to_4bit(layer.weight.data, self.config)
+
+        out_features, in_features = weight_4bit.shape
+        num_weights = out_features * in_features
+        packed_size = (num_weights + 7) // 8
+
+        planes_data = []
+        weight_flat = weight_4bit.flatten().cpu().numpy()
+
+        for plane_idx in range(3):
+            pos_mask = np.zeros(packed_size, dtype=np.uint8)
+            neg_mask = np.zeros(packed_size, dtype=np.uint8)
+
+            for i, weight in enumerate(weight_flat):
+                ternary_coeffs = int4_to_balanced_ternary(int(weight))
+                coeff = ternary_coeffs[plane_idx]
+
+                byte_idx = i // 8
+                bit_idx = i % 8
+
+                if coeff == 1:
+                    pos_mask[byte_idx] |= 1 << bit_idx
+                elif coeff == -1:
+                    neg_mask[byte_idx] |= 1 << bit_idx
+
+            planes_data.append({"pos_mask": pos_mask, "neg_mask": neg_mask})
+
+        weight_bytes = packed_size * 2 * 3
+        scale_bytes = int(metadata["scales"].numel()) * 4
+        total_bytes = weight_bytes + scale_bytes + 16
+
+        self.layers_converted += 1
+        self.total_weights += num_weights
+        self.total_bytes += total_bytes
+
+        bias = layer.bias.data.cpu().numpy() if layer.bias is not None else None
+
+        return {
+            "shape": (out_features, in_features),
+            "group_size": int(metadata["group_size"].item()),
+            "group_scales": metadata["scales"].cpu().numpy(),
+            "plane_scales": np.array([9.0, 3.0, 1.0], dtype=np.float32),
+            "planes": planes_data,
+            "bias": bias,
+        }
+
+    def export_to_file(self, model: nn.Module, output_path: str) -> Dict[str, Dict[str, np.ndarray]]:
+        """Convert all linear layers and persist them to disk."""
+
+        print(f"Exporting model to {output_path}...")
+        converted_layers: Dict[str, Dict[str, np.ndarray]] = {}
+
+        for name, module in model.named_modules():
+            if not isinstance(module, nn.Linear):
+                continue
+
+            if "wte" in name or "wpe" in name or "ln" in name:
+                print(f"  Skipping {name} (embedding/norm layer)")
+                continue
+
+            print(f"  Converting {name}... ", end="")
+            layer_data = self.convert_linear_layer(module)
+            if layer_data:
+                converted_layers[name] = layer_data
+                print(f"✓ ({layer_data['shape'][0]}×{layer_data['shape'][1]})")
+            else:
+                print("skipped")
+
+        with open(output_path, "wb") as f:
+            f.write(b"TERN")
+            f.write(struct.pack("I", 1))
+            f.write(struct.pack("I", len(converted_layers)))
+
+            for name, layer_data in converted_layers.items():
+                name_bytes = name.encode("utf-8")
+                f.write(struct.pack("I", len(name_bytes)))
+                f.write(name_bytes)
+
+                rows, cols = layer_data["shape"]
+                f.write(struct.pack("II", rows, cols))
+                f.write(struct.pack("I", layer_data["group_size"]))
+                f.write(struct.pack("I", len(layer_data["group_scales"])))
+
+                layer_data["plane_scales"].tofile(f)
+                layer_data["group_scales"].tofile(f)
+
+                for plane in layer_data["planes"]:
+                    plane["pos_mask"].tofile(f)
+                    plane["neg_mask"].tofile(f)
+
+                has_bias = layer_data["bias"] is not None
+                f.write(struct.pack("B", 1 if has_bias else 0))
+                if has_bias:
+                    layer_data["bias"].astype(np.float32).tofile(f)
+
+        print("\n✓ Export complete!")
+        print(f"  Layers converted: {self.layers_converted}")
+        print(f"  Total weights: {self.total_weights:,}")
+        print(f"  File size: {self.total_bytes / 1024 / 1024:.2f} MB")
+
+        metadata_path = Path(output_path).with_suffix(".json")
+        metadata = {
+            "model_name": self.model_name,
+            "format": "ternary_multiplane",
+            "version": 1,
+            "layers_converted": self.layers_converted,
+            "total_weights": self.total_weights,
+            "total_bytes": self.total_bytes,
+            "config": {
+                "bits": self.config.bits,
+                "group_size": self.config.group_size,
+                "plane_scales": [9.0, 3.0, 1.0],
+            },
+            "layers": {
+                name: {
+                    "shape": layer["shape"],
+                    "has_bias": layer["bias"] is not None,
+                }
+                for name, layer in converted_layers.items()
+            },
+        }
+
+        with open(metadata_path, "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=2)
+
+        print(f"  Metadata saved to {metadata_path}")
+        return converted_layers
+
+    def verify_export(self, export_path: str) -> None:
+        """Sanity-check that an exported file can be read back."""
+
+        print(f"\nVerifying export {export_path}...")
+        with open(export_path, "rb") as f:
+            magic = f.read(4)
+            assert magic == b"TERN", f"Invalid magic number: {magic}"
+
+            version = struct.unpack("I", f.read(4))[0]
+            assert version == 1, f"Unknown version: {version}"
+
+            num_layers = struct.unpack("I", f.read(4))[0]
+            print(f"  Found {num_layers} layers")
+
+            for _ in range(num_layers):
+                name_len = struct.unpack("I", f.read(4))[0]
+                name = f.read(name_len).decode("utf-8")
+                rows, cols = struct.unpack("II", f.read(8))
+                print(f"    Layer '{name}': {rows}×{cols}")
+
+                group_size = struct.unpack("I", f.read(4))[0]
+                n_groups = struct.unpack("I", f.read(4))[0]
+
+                f.seek(3 * 4, 1)
+                f.seek(n_groups * 4, 1)
+
+                packed_size = (rows * cols + 7) // 8
+                f.seek(packed_size * 2 * 3, 1)
+
+                has_bias = struct.unpack("B", f.read(1))[0]
+                if has_bias:
+                    f.seek(rows * 4, 1)
+
+        print("  ✓ File structure verified")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export model to ternary format")
+    parser.add_argument("--model", type=str, default="gpt2", help="Model name or path")
+    parser.add_argument("--output", type=str, default="model.ternary", help="Output file path")
+    parser.add_argument("--verify", action="store_true", help="Verify the export after writing")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not HAS_TRANSFORMERS:
+        print("Error: transformers library required")
+        print("Install with: pip install transformers torch")
+        return
+
+    assert AutoModelForCausalLM is not None
+
+    print("=" * 70)
+    print("TERNARY MODEL EXPORTER FOR BITNET.CPP")
+    print("=" * 70)
+
+    print(f"\nLoading model: {args.model}")
+    model = AutoModelForCausalLM.from_pretrained(args.model)
+    model.eval()
+
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"Model has {total_params:,} parameters")
+
+    exporter = TernaryModelExporter(args.model)
+    exporter.export_to_file(model, args.output)
+
+    if args.verify:
+        exporter.verify_export(args.output)
+
+    print("\n" + "=" * 70)
+    print("EXPORT COMPLETE")
+    print("=" * 70)
+    print(f"\nModel exported to: {args.output}")
+    print(f"Metadata saved to: {Path(args.output).with_suffix('.json')}")
+    print("\nTo use with BitNet.cpp:")
+    print("1. Copy the .ternary file to your BitNet.cpp models directory")
+    print("2. Update BitNet.cpp with the multiplane kernel (see documentation)")
+    print("3. Run inference with: ./bitnet -m model.ternary")
+    print("\nNote: BitNet.cpp must be modified to support the 3-plane format")
+    print("See the integration guide for details.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/utils/ternary_loader.py
+++ b/utils/ternary_loader.py
@@ -1,0 +1,261 @@
+"""Utilities for loading and materializing ternary multiplane weights."""
+
+from __future__ import annotations
+
+import json
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass
+class TernaryPlane:
+    """Bit-packed ternary mask data for one plane."""
+
+    pos_mask: np.ndarray
+    neg_mask: np.ndarray
+
+
+@dataclass
+class TernaryLayer:
+    """In-memory representation of a ternary multiplane layer."""
+
+    name: str
+    shape: Tuple[int, ...]
+    group_size: int
+    group_scales: np.ndarray
+    plane_scales: np.ndarray
+    planes: List[TernaryPlane]
+    bias: Optional[np.ndarray]
+
+    @property
+    def rows(self) -> int:
+        return int(self.shape[0]) if self.shape else 0
+
+    @property
+    def cols(self) -> int:
+        if len(self.shape) >= 2:
+            return int(np.prod(self.shape[1:]))
+        return 1 if self.shape else 0
+
+
+@dataclass
+class TernaryModel:
+    """Container for an exported ternary model."""
+
+    layers: Dict[str, TernaryLayer]
+    metadata: Dict[str, object]
+
+
+def _read_uint32(handle) -> int:
+    data = handle.read(4)
+    if len(data) != 4:
+        raise EOFError("Unexpected end of file while reading uint32")
+    return struct.unpack("<I", data)[0]
+
+
+def _read_float32_array(handle, count: int) -> np.ndarray:
+    if count == 0:
+        return np.zeros((0,), dtype=np.float32)
+    buffer = handle.read(4 * count)
+    if len(buffer) != 4 * count:
+        raise EOFError("Unexpected end of file while reading float array")
+    return np.frombuffer(buffer, dtype=np.float32).copy()
+
+
+def _read_mask(handle, size: int) -> np.ndarray:
+    buffer = handle.read(size)
+    if len(buffer) != size:
+        raise EOFError("Unexpected end of file while reading mask")
+    return np.frombuffer(buffer, dtype=np.uint8).copy()
+
+
+def _load_metadata(path: Path) -> Dict[str, object]:
+    metadata_path = path.with_suffix(".json")
+    if metadata_path.exists():
+        with metadata_path.open("r", encoding="utf-8") as descriptor:
+            return json.load(descriptor)
+    return {}
+
+
+def is_ternary_file(path: Path) -> bool:
+    """Return True when the file looks like a ternary export."""
+
+    try:
+        with Path(path).open("rb") as handle:
+            return handle.read(4) == b"TERN"
+    except OSError:
+        return False
+
+
+def _read_shape(handle, dims: int) -> Tuple[int, ...]:
+    shape: List[int] = []
+    for _ in range(dims):
+        shape.append(_read_uint32(handle))
+    return tuple(shape)
+
+
+def _load_version1_layers(handle) -> Dict[str, TernaryLayer]:
+    layers: Dict[str, TernaryLayer] = {}
+
+    layer_count = _read_uint32(handle)
+
+    for _ in range(layer_count):
+        name_length = _read_uint32(handle)
+        name_bytes = handle.read(name_length)
+        if len(name_bytes) != name_length:
+            raise EOFError("Unexpected end of file while reading layer name")
+        name = name_bytes.decode("utf-8")
+
+        rows = _read_uint32(handle)
+        cols = _read_uint32(handle)
+        group_size = _read_uint32(handle)
+        n_groups = _read_uint32(handle)
+
+        plane_scales = _read_float32_array(handle, 3)
+        group_scales = _read_float32_array(handle, n_groups)
+
+        packed_size = (rows * cols + 7) // 8
+        planes: List[TernaryPlane] = []
+        for _plane in range(3):
+            pos_mask = _read_mask(handle, packed_size)
+            neg_mask = _read_mask(handle, packed_size)
+            planes.append(TernaryPlane(pos_mask=pos_mask, neg_mask=neg_mask))
+
+        bias_flag = handle.read(1)
+        if len(bias_flag) != 1:
+            raise EOFError("Unexpected end of file while reading bias flag")
+        has_bias = struct.unpack("<B", bias_flag)[0] == 1
+        bias = None
+        if has_bias:
+            bias = _read_float32_array(handle, rows)
+
+        layers[name] = TernaryLayer(
+            name=name,
+            shape=(rows, cols),
+            group_size=group_size,
+            group_scales=group_scales,
+            plane_scales=plane_scales,
+            planes=planes,
+            bias=bias,
+        )
+
+    return layers
+
+
+def _load_version3_layers(handle) -> Tuple[Dict[str, TernaryLayer], Dict[str, object]]:
+    layers: Dict[str, TernaryLayer] = {}
+
+    layer_count = _read_uint32(handle)
+
+    format_length = _read_uint32(handle)
+    format_bytes = handle.read(format_length)
+    if len(format_bytes) != format_length:
+        raise EOFError("Unexpected end of file while reading format name")
+    format_name = format_bytes.decode("utf-8") if format_bytes else ""
+
+    metadata_length = _read_uint32(handle)
+    metadata_blob = handle.read(metadata_length)
+    if len(metadata_blob) != metadata_length:
+        raise EOFError("Unexpected end of file while reading metadata block")
+    metadata: Dict[str, object] = {}
+    if metadata_blob:
+        metadata = json.loads(metadata_blob.decode("utf-8"))
+
+    if format_name and "source_format" not in metadata:
+        metadata["source_format"] = format_name
+
+    for _ in range(layer_count):
+        name_length = _read_uint32(handle)
+        name_bytes = handle.read(name_length)
+        if len(name_bytes) != name_length:
+            raise EOFError("Unexpected end of file while reading layer name")
+        name = name_bytes.decode("utf-8")
+
+        ndim = _read_uint32(handle)
+        shape = _read_shape(handle, ndim)
+        if not shape:
+            total_weights = 0
+        else:
+            total_weights = int(np.prod(shape))
+
+        group_size = _read_uint32(handle)
+        n_groups = _read_uint32(handle)
+
+        plane_scales = _read_float32_array(handle, 3)
+        group_scales = _read_float32_array(handle, n_groups)
+
+        packed_size = (total_weights + 7) // 8
+        planes: List[TernaryPlane] = []
+        for _plane in range(3):
+            pos_mask = _read_mask(handle, packed_size)
+            neg_mask = _read_mask(handle, packed_size)
+            planes.append(TernaryPlane(pos_mask=pos_mask, neg_mask=neg_mask))
+
+        layers[name] = TernaryLayer(
+            name=name,
+            shape=shape,
+            group_size=group_size,
+            group_scales=group_scales,
+            plane_scales=plane_scales,
+            planes=planes,
+            bias=None,
+        )
+
+    return layers, metadata
+
+
+def load_ternary_model(path: Path) -> TernaryModel:
+    """Parse a ternary model export into an in-memory structure."""
+
+    path = Path(path)
+
+    with path.open("rb") as handle:
+        magic = handle.read(4)
+        if magic != b"TERN":
+            raise ValueError("File is not a ternary export (missing magic header)")
+
+        version = _read_uint32(handle)
+
+        if version == 1:
+            layers = _load_version1_layers(handle)
+            metadata = _load_metadata(path)
+        elif version == 3:
+            layers, metadata = _load_version3_layers(handle)
+            external_metadata = _load_metadata(path)
+            if external_metadata:
+                metadata = {**metadata, **external_metadata}
+        else:
+            raise ValueError(f"Unsupported ternary export version: {version}")
+
+    return TernaryModel(layers=layers, metadata=metadata)
+
+
+def materialize_layer(layer: TernaryLayer) -> np.ndarray:
+    """Convert a ternary layer into floating-point weights."""
+
+    if layer.shape:
+        total_weights = int(np.prod(layer.shape))
+    else:
+        total_weights = 0
+    if total_weights == 0:
+        return np.zeros(layer.shape, dtype=np.float32)
+
+    accumulator = np.zeros(total_weights, dtype=np.float32)
+
+    for plane_index, plane in enumerate(layer.planes):
+        pos_bits = np.unpackbits(plane.pos_mask, bitorder="little", count=total_weights)
+        neg_bits = np.unpackbits(plane.neg_mask, bitorder="little", count=total_weights)
+        coeff = pos_bits.astype(np.int8) - neg_bits.astype(np.int8)
+        accumulator += coeff.astype(np.float32) * layer.plane_scales[plane_index]
+
+    if layer.group_scales.size > 0:
+        group_indices = np.arange(total_weights) // max(layer.group_size, 1)
+        group_indices = np.clip(group_indices, 0, layer.group_scales.size - 1)
+        accumulator *= layer.group_scales[group_indices]
+
+    return accumulator.reshape(layer.shape)
+


### PR DESCRIPTION
## Summary
- extend the ternary loader to parse both legacy v1 and unified v3 exports, including embedded metadata
- represent ternary layers with arbitrary shapes so weights materialize correctly under either format

## Testing
- python -m compileall run_inference.py run_inference_server.py utils/ternary_loader.py utils/export_ternary_model.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c14cb4d4832d9171b1dde3622658