### PR TITLE
Improve ternary hydration resolution and bias support

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -1,11 +1,12 @@
 import argparse
 import os
 import platform
+import re
 import signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 from utils.ternary_loader import (
     TernaryModel,
@@ -75,6 +76,103 @@ def _load_transformers():
     return AutoModelForCausalLM, AutoTokenizer
 
 
+_LLAMA_CPP_STATIC_ALIASES = {
+    "token_embd.weight": "model.embed_tokens.weight",
+    "token_embd.bias": "model.embed_tokens.bias",
+    "output.weight": "lm_head.weight",
+    "output.bias": "lm_head.bias",
+    "output_norm.weight": "model.norm.weight",
+    "output_norm.bias": "model.norm.bias",
+}
+
+
+_LLAMA_CPP_PATTERN_ALIASES = [
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.attn_q\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.self_attn.q_proj.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.attn_k\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.self_attn.k_proj.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.attn_v\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.self_attn.v_proj.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.attn_output\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.self_attn.o_proj.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.attn_norm\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.input_layernorm.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.ffn_norm\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.post_attention_layernorm.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.ffn_up\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.mlp.up_proj.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.ffn_gate\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.mlp.gate_proj.{param}",
+    ),
+    (
+        re.compile(r"^blk\.(?P<i>\d+)\.ffn_down\.(?P<param>weight|bias)$"),
+        "model.layers.{i}.mlp.down_proj.{param}",
+    ),
+]
+
+
+def _alias_hf_name(layer_name: str) -> Optional[str]:
+    if layer_name in _LLAMA_CPP_STATIC_ALIASES:
+        return _LLAMA_CPP_STATIC_ALIASES[layer_name]
+    for pattern, target in _LLAMA_CPP_PATTERN_ALIASES:
+        match = pattern.match(layer_name)
+        if match:
+            return target.format(**match.groupdict())
+    return None
+
+
+def _resolve_module(
+    named_modules: dict,
+    named_parameters: dict,
+    named_buffers: dict,
+    layer_name: str,
+) -> Tuple[Optional[object], Optional[str]]:
+    """Return the owning module and attribute for a ternary layer."""
+
+    def _resolve_candidate(candidate: str) -> Tuple[Optional[object], Optional[str]]:
+        module = named_modules.get(candidate)
+        if module is not None and hasattr(module, "weight"):
+            return module, "weight"
+
+        if candidate in named_parameters or candidate in named_buffers:
+            if "." in candidate:
+                module_name, attribute = candidate.rsplit(".", 1)
+                module = named_modules.get(module_name)
+                if module is not None and hasattr(module, attribute):
+                    return module, attribute
+        elif "." in candidate:
+            module_name, attribute = candidate.rsplit(".", 1)
+            module = named_modules.get(module_name)
+            if module is not None and hasattr(module, attribute):
+                return module, attribute
+
+        return None, None
+
+    for candidate in (layer_name, _alias_hf_name(layer_name)):
+        if not candidate:
+            continue
+        module, attribute = _resolve_candidate(candidate)
+        if module is not None:
+            return module, attribute
+
+    return None, None
+
+
 def _prepare_hf_components(model_metadata: dict, hf_override: Optional[str]):
     AutoModelForCausalLM, AutoTokenizer = _load_transformers()
     model_name = hf_override or model_metadata.get("model_name")
@@ -95,19 +193,61 @@ def _apply_ternary_weights(model, ternary_model: TernaryModel):
     import torch
 
     named_modules = dict(model.named_modules())
+    named_parameters = dict(model.named_parameters())
+    named_buffers = dict(model.named_buffers())
     for layer_name, layer in ternary_model.layers.items():
-        module = named_modules.get(layer_name)
-        if module is None or not hasattr(module, "weight"):
+        module, attribute = _resolve_module(
+            named_modules, named_parameters, named_buffers, layer_name
+        )
+        if module is None or attribute is None:
             print(f"Warning: layer '{layer_name}' not found in base model; skipping.")
             continue
 
         weights = materialize_layer(layer)
-        weight_tensor = torch.from_numpy(weights).to(module.weight.dtype)
-        module.weight.data.copy_(weight_tensor)
+        target_param = getattr(module, attribute, None)
+        if target_param is None:
+            print(
+                "Warning: resolved attribute '"
+                f"{attribute}' for layer '{layer_name}' missing on base model; skipping."
+            )
+            continue
 
-        if layer.bias is not None and getattr(module, "bias", None) is not None:
-            bias_tensor = torch.from_numpy(layer.bias).to(module.bias.dtype)
-            module.bias.data.copy_(bias_tensor)
+        weight_tensor = torch.from_numpy(weights).to(
+            dtype=target_param.dtype, device=target_param.device
+        )
+
+        if weight_tensor.shape != target_param.shape:
+            if (
+                weight_tensor.ndim == target_param.ndim == 2
+                and weight_tensor.t().shape == target_param.shape
+            ):
+                weight_tensor = weight_tensor.t().contiguous()
+            else:
+                print(
+                    "Warning: layer '"
+                    f"{layer_name}' resolved to '{attribute}' with mismatched shape "
+                    f"{weight_tensor.shape} != {tuple(target_param.shape)}; skipping."
+                )
+                continue
+
+        target_param.data.copy_(weight_tensor)
+
+        if (
+            attribute != "bias"
+            and layer.bias is not None
+            and getattr(module, "bias", None) is not None
+        ):
+            bias_tensor = torch.from_numpy(layer.bias).to(
+                dtype=module.bias.dtype, device=module.bias.device
+            )
+            if bias_tensor.shape != module.bias.shape:
+                print(
+                    "Warning: bias for layer '"
+                    f"{layer_name}' has mismatched shape {bias_tensor.shape} "
+                    f"!= {tuple(module.bias.shape)}; skipping bias update."
+                )
+            else:
+                module.bias.data.copy_(bias_tensor)
 
 
 def run_ternary_inference(args):

--- a/tests/test_run_inference.py
+++ b/tests/test_run_inference.py
@@ -1,0 +1,197 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+import torch
+
+from transformers import LlamaConfig, LlamaForCausalLM
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from run_inference import _apply_ternary_weights
+from utils.ternary_loader import TernaryLayer, TernaryModel, TernaryPlane
+
+
+def _make_ternary_layer(
+    name: str, weights: np.ndarray, bias: np.ndarray | None = None
+) -> TernaryLayer:
+    weights = np.asarray(weights, dtype=np.float32)
+    flat = weights.reshape(-1)
+    if weights.ndim == 0:
+        shape = ()
+        group_size = 1
+    else:
+        shape = weights.shape
+        group_size = shape[-1] if shape[-1] > 0 else 1
+
+    total = flat.size
+    if group_size <= 0:
+        group_size = 1
+    n_groups = int(np.ceil(total / group_size)) if total else 0
+    group_scales = np.ones((n_groups,), dtype=np.float32)
+
+    def pack(bits: np.ndarray) -> np.ndarray:
+        if bits.size == 0:
+            return np.zeros((0,), dtype=np.uint8)
+        return np.packbits(bits.astype(np.uint8), bitorder="little")
+
+    positive = pack(flat > 0)
+    negative = pack(flat < 0)
+    zero_mask = np.zeros_like(positive)
+
+    planes = [
+        TernaryPlane(pos_mask=positive, neg_mask=negative),
+        TernaryPlane(pos_mask=zero_mask, neg_mask=zero_mask),
+        TernaryPlane(pos_mask=zero_mask, neg_mask=zero_mask),
+    ]
+
+    plane_scales = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+
+    return TernaryLayer(
+        name=name,
+        shape=shape,
+        group_size=int(group_size),
+        group_scales=group_scales,
+        plane_scales=plane_scales,
+        planes=planes,
+        bias=None if bias is None else np.asarray(bias, dtype=np.float32),
+    )
+
+
+def test_apply_ternary_weights_resolves_llama_cpp_aliases():
+    config = LlamaConfig(
+        vocab_size=16,
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+    )
+    model = LlamaForCausalLM(config)
+
+    q_weight = np.array(
+        [
+            [1, -1, 0, 1],
+            [-1, 1, 1, -1],
+            [0, 1, -1, 1],
+            [1, 0, -1, -1],
+        ],
+        dtype=np.float32,
+    )
+    norm_weight = np.array([1.0, -1.0, 0.0, 1.0], dtype=np.float32)
+    lm_head_weight = np.array(
+        [
+            [1, -1, 0, 1, -1, 1, 0, -1, 1, 0, -1, 1, 0, 1, -1, 0],
+            [-1, 1, 1, -1, 0, -1, 1, 0, -1, 1, 0, -1, 1, 0, 1, -1],
+            [0, 1, -1, 1, -1, 0, 1, -1, 0, 1, -1, 0, 1, -1, 0, 1],
+            [1, 0, -1, -1, 1, -1, 0, 1, -1, 0, 1, -1, 0, 1, -1, 0],
+        ],
+        dtype=np.float32,
+    )
+
+    layers = {
+        "blk.0.attn_q.weight": _make_ternary_layer("blk.0.attn_q.weight", q_weight),
+        "blk.0.attn_norm.weight": _make_ternary_layer("blk.0.attn_norm.weight", norm_weight),
+        "output.weight": _make_ternary_layer("output.weight", lm_head_weight),
+    }
+
+    ternary_model = TernaryModel(layers=layers, metadata={})
+
+    _apply_ternary_weights(model, ternary_model)
+
+    q_proj_weight = (
+        model.model.layers[0].self_attn.q_proj.weight.detach().cpu().numpy()
+    )
+    assert np.allclose(q_proj_weight, q_weight)
+
+    norm_tensor = (
+        model.model.layers[0].input_layernorm.weight.detach().cpu().numpy()
+    )
+    assert np.allclose(norm_tensor, norm_weight)
+
+    lm_head_tensor = model.lm_head.weight.detach().cpu().numpy()
+    assert np.allclose(lm_head_tensor, lm_head_weight.T)
+
+
+def test_apply_ternary_weights_handles_direct_hf_names():
+    config = LlamaConfig(
+        vocab_size=16,
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+    )
+    model = LlamaForCausalLM(config)
+
+    up_weight = np.array(
+        [
+            [1, -1, 0, 1],
+            [-1, 1, 1, 0],
+            [0, 1, -1, -1],
+            [1, 0, 1, -1],
+            [-1, -1, 0, 1],
+            [1, 1, -1, 0],
+            [0, -1, 1, 1],
+            [-1, 0, 0, 1],
+        ],
+        dtype=np.float32,
+    )
+    down_weight = np.array(
+        [
+            [1, 0, -1, 1, -1, 1, 0, -1],
+            [-1, 1, 0, -1, 1, -1, 0, 1],
+            [0, -1, 1, 0, -1, 1, -1, 0],
+            [1, 1, -1, 0, 0, 1, 1, -1],
+        ],
+        dtype=np.float32,
+    )
+    norm_weight = np.array([1, -1, 0, 1], dtype=np.float32)
+
+    layers = {
+        "blk.0.ffn_up.weight": _make_ternary_layer("blk.0.ffn_up.weight", up_weight),
+        "model.layers.0.mlp.down_proj.weight": _make_ternary_layer(
+            "model.layers.0.mlp.down_proj.weight", down_weight
+        ),
+        "blk.0.attn_norm.weight": _make_ternary_layer(
+            "blk.0.attn_norm.weight", norm_weight
+        ),
+    }
+
+    ternary_model = TernaryModel(layers=layers, metadata={})
+
+    _apply_ternary_weights(model, ternary_model)
+
+    up_proj = model.model.layers[0].mlp.up_proj
+    assert np.allclose(up_proj.weight.detach().cpu().numpy(), up_weight)
+    down_proj = model.model.layers[0].mlp.down_proj
+    assert np.allclose(down_proj.weight.detach().cpu().numpy(), down_weight)
+
+    attn_norm = model.model.layers[0].input_layernorm
+    assert np.allclose(attn_norm.weight.detach().cpu().numpy(), norm_weight)
+
+
+def test_apply_ternary_weights_updates_bias_when_present():
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.dense = torch.nn.Linear(3, 3, bias=True)
+
+    model = DummyModel()
+
+    weight = np.array(
+        [[1, -1, 0], [-1, 1, 1], [0, -1, 1]], dtype=np.float32
+    )
+    bias = np.array([0.25, -0.5, 1.0], dtype=np.float32)
+
+    layers = {
+        "dense.weight": _make_ternary_layer("dense.weight", weight, bias=bias)
+    }
+
+    ternary_model = TernaryModel(layers=layers, metadata={})
+
+    _apply_ternary_weights(model, ternary_model)
+
+    assert np.allclose(model.dense.weight.detach().cpu().numpy(), weight)
+    assert np.allclose(model.dense.bias.detach().cpu().numpy(), bias)
+


### PR DESCRIPTION
## Summary
- expand ternary layer resolution to consult named parameters/buffers and guard bias shape mismatches during hydration
- extend ternary hydration tests to cover direct Hugging Face names and bias updates using dummy modules
- add helper flexibility for constructing ternary layers with optional bias payloads

## Testing
- python -m pytest tests/test_run_inference.py

------
https://chatgpt.com/codex/tasks/task_e_68dcddf7c8d4832db3619771831829f8